### PR TITLE
feat: update URL for WebBaseLoader to use DocAddr environment variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,11 +44,16 @@ from langchain.prompts import PromptTemplate
 # get channel_secret and channel_access_token from your environment variable
 channel_secret = os.getenv('ChannelSecret', None)
 channel_access_token = os.getenv('ChannelAccessToken', None)
+doc_addr = os.getenv('DocAddr', None)
+
 if channel_secret is None:
     print('Specify LINE_CHANNEL_SECRET as environment variable.')
     sys.exit(1)
 if channel_access_token is None:
     print('Specify LINE_CHANNEL_ACCESS_TOKEN as environment variable.')
+    sys.exit(1)
+if doc_addr is None:
+    print('Specify DocAddr as environment variable.')
     sys.exit(1)
 
 app = FastAPI()
@@ -58,8 +63,7 @@ line_bot_api = AsyncLineBotApi(channel_access_token, async_http_client)
 parser = WebhookParser(channel_secret)
 
 # Document Loader
-doc = WebBaseLoader(
-    "https://gist.githubusercontent.com/kkdai/93ee54d7a03205c54b7dc1cfb262cc62/raw/5c741eec3d523e344104a7081acfbef205de5491/Q&A1.txt")
+doc = WebBaseLoader(doc_addr)
 documents = doc.load()
 
 # Text Splitter


### PR DESCRIPTION
- Add a check for the existence of the `DocAddr` environment variable
- Specify the `DocAddr` environment variable when it is not provided
- Change the URL for the `WebBaseLoader` to use the `DocAddr` environment variable